### PR TITLE
Reverse graffiti scroll direction

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,7 +35,8 @@ function showRandomGraffiti() {
   img.className = "graffiti-image";
 
   img.onload = () => {
-    scrollX = 0;
+    // Start at the rightmost edge so the image scrolls from right to left
+    scrollX = window.innerWidth - img.width;
     scrollInterval = setInterval(() => scrollImage(img), 30);
   };
 
@@ -50,12 +51,12 @@ function showRandomGraffiti() {
 
 // Scroll image horizontally
 function scrollImage(img) {
-  scrollX -= 2;
+  scrollX += 2;
   img.style.transform = `translate(${scrollX}px, -50%)`;
 
   const maxScroll = img.width - window.innerWidth;
-  if (Math.abs(scrollX) >= maxScroll) {
-    scrollX = 0;
+  if (scrollX >= 0) {
+    scrollX = -maxScroll;
   }
 }
 


### PR DESCRIPTION
## Summary
- update graffiti scroll logic so images move from right to left

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d493a6c9c83238251c146ef9534b0